### PR TITLE
fix: wrong export of rules in base

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paratco/eslint-config",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "type": "module",
   "author": "Paratco",
   "license": "ISC",

--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -10,8 +10,8 @@ import unicornRules from "../rules/unicorn.js";
 export default [
   // Set predefined configs
   eslint.configs.recommended,
-  tsEslint.configs.strictTypeChecked,
-  tsEslint.configs.stylisticTypeChecked,
+  ...tsEslint.configs.strictTypeChecked,
+  ...tsEslint.configs.stylisticTypeChecked,
   eslintPluginUnicorn.configs.recommended,
 
   // JavaScript Rules


### PR DESCRIPTION
This pull request includes changes to the `@paratco/eslint-config` package to update its version and improve the configuration setup for TypeScript ESLint rules.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `2.3.0` to `2.3.1`.

Configuration improvement:

* [`src/configs/base.ts`](diffhunk://#diff-53974ea65bc3c5e1194d6e892a67f8c00ec10f2b26c5b844819e9b30d5019f8bL13-R14): Modified the inclusion of TypeScript ESLint configurations by spreading the `strictTypeChecked` and `stylisticTypeChecked` configs to ensure all nested rules are applied.