### PR TITLE
fix: removed unused-imports/no-unused-vars

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -171,8 +171,8 @@
     "unicorn/numeric-separators-style": "error",
     "unicorn/prefer-add-event-listener": "error",
     "unicorn/prefer-array-find": "error",
-    "unicorn/prefer-array-flat-map": "error",
     "unicorn/prefer-array-flat": "error",
+    "unicorn/prefer-array-flat-map": "error",
     "unicorn/prefer-array-index-of": "error",
     "unicorn/prefer-array-some": "error",
     "unicorn/prefer-blob-reading-methods": "error",
@@ -524,9 +524,6 @@
           }
         ],
         "import-x/prefer-default-export": [
-          "off"
-        ],
-        "no-unused-vars": [
           "off"
         ]
       }

--- a/src/configs/import.ts
+++ b/src/configs/import.ts
@@ -32,20 +32,7 @@ export default function importConfig(typescript?: TypescriptOptions): Linter.Con
         ...importXRules,
 
         // unused-imports
-        "no-unused-vars": ["off"],
-        "@typescript-eslint/no-unused-vars": ["off"],
-        "unused-imports/no-unused-imports": ["error"],
-        "unused-imports/no-unused-vars": [
-          "error",
-          {
-            args: "all",
-            argsIgnorePattern: "^_",
-            caughtErrors: "all",
-            caughtErrorsIgnorePattern: "^_",
-            destructuredArrayIgnorePattern: "^_",
-            ignoreRestSiblings: true
-          }
-        ]
+        "unused-imports/no-unused-imports": ["error"]
       }
     }
   ] as Linter.Config[];


### PR DESCRIPTION
resolves #265 
This pull request focuses on updating unused variable linting rules and making minor adjustments to the `.oxlintrc.json` configuration. The primary change is the removal of custom unused variable rules in favor of relying solely on the `unused-imports/no-unused-imports` rule.

Linting configuration updates:

* Removed `no-unused-vars` and `@typescript-eslint/no-unused-vars` rules from the `importConfig` function in `src/configs/import.ts`, as well as the custom configuration for `unused-imports/no-unused-vars`, leaving only `unused-imports/no-unused-imports` enabled.
* Cleaned up `.oxlintrc.json` by removing the `no-unused-vars` rule from the overrides section.