### PR TITLE
feat: added bun to typescript resolver

### DIFF
--- a/src/configs/import.ts
+++ b/src/configs/import.ts
@@ -9,7 +9,7 @@ import importXRules from "../rules/import";
 import type { TypescriptOptions } from "../types";
 
 export default function importConfig(typescript?: TypescriptOptions): Linter.Config[] {
-  const resolverOptions: TypeScriptResolverOptions = { alwaysTryTypes: true };
+  const resolverOptions: TypeScriptResolverOptions = { alwaysTryTypes: true, bun: true };
 
   if (typescript !== undefined) {
     resolverOptions.project = typescript.project;

--- a/src/rules/import.ts
+++ b/src/rules/import.ts
@@ -13,7 +13,7 @@ export default {
   // Forbid the use of extraneous packages.
   "import-x/no-extraneous-dependencies": [
     "error",
-    { devDependencies: false, optionalDependencies: false, peerDependencies: false }
+    { devDependencies: false, optionalDependencies: false }
   ],
 
   // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-mutable-exports.md


### PR DESCRIPTION
resolves #266 
This pull request introduces a minor update to the import rules configuration, primarily to support Bun and adjust dependency checks.

Import resolver improvements:

* Added the `bun: true` option to the TypeScript resolver configuration in `importConfig`, enabling compatibility with Bun.

Dependency rule adjustments:

* Removed the check for `peerDependencies` from the `import-x/no-extraneous-dependencies` rule, so peer dependencies are no longer flagged as extraneous.